### PR TITLE
Install Chrome before running linkspector

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install Chrome for Puppeteer
-        run: npx --yes puppeteer browsers install chrome
+        run: npx --yes @puppeteer/browsers install chrome@148.0.7778.97
       - name: Run linkspector
         uses: umbrelladocs/action-linkspector@v1
         with:

--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -10,6 +10,8 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
+      - name: Install Chrome for Puppeteer
+        run: npx --yes puppeteer browsers install chrome
       - name: Run linkspector
         uses: umbrelladocs/action-linkspector@v1
         with:

--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install Chrome for Puppeteer
-        run: npx --yes @puppeteer/browsers install chrome@148.0.7778.97
+        run: npx --yes @puppeteer/browsers install chrome@148.0.7778.97 --path "$HOME/.cache/puppeteer"
       - name: Run linkspector
         uses: umbrelladocs/action-linkspector@v1
         with:


### PR DESCRIPTION
## Summary
- Linkspector's Puppeteer step has been failing on CI with `Could not find Chrome (ver. 148.0.7778.97)`, aborting before any links are actually checked.
- Add an explicit `npx puppeteer browsers install chrome` step in the Linkspector workflow so the expected browser is present in the runner's Puppeteer cache before linkspector starts.

## Test plan
- [ ] CI Linkspector check on this PR runs to completion (instead of failing on Chrome discovery).
- [ ] No new link errors are reported (this PR does not change any links).

🤖 Generated with [Claude Code](https://claude.com/claude-code)